### PR TITLE
Lease Rejection

### DIFF
--- a/tools/leaderelection/leaderelection.go
+++ b/tools/leaderelection/leaderelection.go
@@ -240,8 +240,8 @@ func (le *LeaderElector) IsLeader() bool {
 	return le.getObservedRecord().HolderIdentity == le.config.Lock.Identity()
 }
 
-func (le *LeaderElector) IsOusted() bool {
-	return le.getObservedRecord().OustedIdentity == le.config.Lock.Identity()
+func (le *LeaderElector) IsRejected() bool {
+	return le.getObservedRecord().RejectedHolderIdentity == le.config.Lock.Identity()
 }
 
 // acquire loops calling tryAcquireOrRenew and returns true immediately when tryAcquireOrRenew succeeds.
@@ -359,8 +359,9 @@ func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 		return false
 	}
 
-	if le.IsOusted() {
-		klog.V(4).Infof("lock indicates %v is ousted, aborting update", oldLeaderElectionRecord.OustedIdentity)
+	if le.IsRejected() {
+		klog.V(4).Infof("lock indicates %v is rejected, aborting update", oldLeaderElectionRecord.RejectedHolderIdentity)
+		return false
 	}
 
 	// 3. We're going to try to update. The leaderElectionRecord is set to it's default

--- a/tools/leaderelection/leaderelection.go
+++ b/tools/leaderelection/leaderelection.go
@@ -240,6 +240,10 @@ func (le *LeaderElector) IsLeader() bool {
 	return le.getObservedRecord().HolderIdentity == le.config.Lock.Identity()
 }
 
+func (le *LeaderElector) IsOusted() bool {
+	return le.getObservedRecord().OustedIdentity == le.config.Lock.Identity()
+}
+
 // acquire loops calling tryAcquireOrRenew and returns true immediately when tryAcquireOrRenew succeeds.
 // Returns false if ctx signals done.
 func (le *LeaderElector) acquire(ctx context.Context) bool {
@@ -353,6 +357,10 @@ func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 		!le.IsLeader() {
 		klog.V(4).Infof("lock is held by %v and has not yet expired", oldLeaderElectionRecord.HolderIdentity)
 		return false
+	}
+
+	if le.IsOusted() {
+		klog.V(4).Infof("lock indicates %v is ousted, aborting update", oldLeaderElectionRecord.OustedIdentity)
 	}
 
 	// 3. We're going to try to update. The leaderElectionRecord is set to it's default

--- a/tools/leaderelection/resourcelock/interface.go
+++ b/tools/leaderelection/resourcelock/interface.go
@@ -119,6 +119,9 @@ type LeaderElectionRecord struct {
 	AcquireTime          metav1.Time `json:"acquireTime"`
 	RenewTime            metav1.Time `json:"renewTime"`
 	LeaderTransitions    int         `json:"leaderTransitions"`
+	// OustedIdentity is the ID of the current or a potential holder who will not attempt to acquire
+	// the lease further.
+	OustedIdentity string `json:"oustedIdentity"`
 }
 
 // EventRecorder records a change in the ResourceLock.

--- a/tools/leaderelection/resourcelock/interface.go
+++ b/tools/leaderelection/resourcelock/interface.go
@@ -114,14 +114,12 @@ type LeaderElectionRecord struct {
 	// attempt to acquire leases with empty identities and will wait for the full lease
 	// interval to expire before attempting to reacquire. This value is set to empty when
 	// a client voluntarily steps down.
-	HolderIdentity       string      `json:"holderIdentity"`
-	LeaseDurationSeconds int         `json:"leaseDurationSeconds"`
-	AcquireTime          metav1.Time `json:"acquireTime"`
-	RenewTime            metav1.Time `json:"renewTime"`
-	LeaderTransitions    int         `json:"leaderTransitions"`
-	// OustedIdentity is the ID of the current or a potential holder who will not attempt to acquire
-	// the lease further.
-	OustedIdentity string `json:"oustedIdentity"`
+	HolderIdentity         string      `json:"holderIdentity"`
+	LeaseDurationSeconds   int         `json:"leaseDurationSeconds"`
+	AcquireTime            metav1.Time `json:"acquireTime"`
+	RenewTime              metav1.Time `json:"renewTime"`
+	LeaderTransitions      int         `json:"leaderTransitions"`
+	RejectedHolderIdentity string      `json:"rejectedHolderIdentity"`
 }
 
 // EventRecorder records a change in the ResourceLock.

--- a/tools/leaderelection/resourcelock/leaselock.go
+++ b/tools/leaderelection/resourcelock/leaselock.go
@@ -45,6 +45,9 @@ func (ll *LeaseLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, er
 	}
 	ll.lease = lease
 	record := LeaseSpecToLeaderElectionRecord(&ll.lease.Spec)
+	if oustedIdentity, ok := lease.Annotations["oustedIdentity"]; ok {
+		record.OustedIdentity = oustedIdentity
+	}
 	recordByte, err := json.Marshal(*record)
 	if err != nil {
 		return nil, nil, err

--- a/tools/leaderelection/resourcelock/leaselock.go
+++ b/tools/leaderelection/resourcelock/leaselock.go
@@ -45,8 +45,8 @@ func (ll *LeaseLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, er
 	}
 	ll.lease = lease
 	record := LeaseSpecToLeaderElectionRecord(&ll.lease.Spec)
-	if oustedIdentity, ok := lease.Annotations["oustedIdentity"]; ok {
-		record.OustedIdentity = oustedIdentity
+	if rejectedHolderIdentity, ok := lease.Annotations["kubernetes.io/reject-holder-identity"]; ok {
+		record.RejectedHolderIdentity = rejectedHolderIdentity
 	}
 	recordByte, err := json.Marshal(*record)
 	if err != nil {


### PR DESCRIPTION
Adding an annotation which indicates the rejected lease. The lease holder's acquire and renew attempt will intentionally avoid updating the lease object if this annotation is set, allowing for the lease to expire.